### PR TITLE
feat: add --strings and --tuning support to web demo

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,16 +354,37 @@ pub fn chord_to_svg(
     show_ox: bool,
     fret_offset: u32,
     show_notes: bool,
+    strings: u32,
+    tuning: &str,
 ) -> String {
-    use chord::{best_caged_voicing, parse_chord_name};
-    let string_open = get_string_open(6);
+    use chord::{best_caged_voicing, best_voicing_for_tuning, parse_chord_name};
 
-    let frets = if let Some(f) = parse_fret_string(input, 6) {
+    let string_open_owned: Vec<u8>;
+    let string_open: &[u8] = if !tuning.is_empty() {
+        match parse_tuning(tuning) {
+            Some(v) => { string_open_owned = v; &string_open_owned }
+            None => return format!("<!-- Error: Invalid tuning '{}' -->", tuning),
+        }
+    } else {
+        get_string_open(strings)
+    };
+
+    let num_strings = string_open.len();
+
+    let frets = if let Some(f) = parse_fret_string(input, num_strings) {
         f
     } else if let Some(chord_name) = parse_chord_name(input) {
-        match best_caged_voicing(&chord_name) {
-            Some((f, _fo)) => f,
-            None => return format!("<!-- Error: No voicing found for '{}' -->", input),
+        let is_standard = string_open == get_string_open(6);
+        if is_standard {
+            match best_caged_voicing(&chord_name) {
+                Some((f, _fo)) => f,
+                None => return format!("<!-- Error: No voicing found for '{}' -->", input),
+            }
+        } else {
+            match best_voicing_for_tuning(&chord_name, string_open) {
+                Some((f, _fo)) => f,
+                None => return format!("<!-- Error: No voicing found for '{}' -->", input),
+            }
         }
     } else {
         return format!("<!-- Error: Cannot parse input '{}' -->", input);

--- a/www/index.html
+++ b/www/index.html
@@ -92,6 +92,21 @@
       <label><input type="checkbox" id="show_notes" /> Show note names</label>
     </div>
 
+    <div style="display:flex; gap:1rem; margin-bottom:1rem; flex-wrap:wrap; align-items:flex-end;">
+      <div>
+        <label for="strings" style="margin-bottom:0.3rem;">Strings</label>
+        <select id="strings" style="padding:0.45rem 0.6rem; border:1px solid #ccc; border-radius:6px; font-size:0.95rem;">
+          <option value="4">4 (Bass)</option>
+          <option value="6" selected>6 (Guitar)</option>
+          <option value="7">7 (7-string)</option>
+        </select>
+      </div>
+      <div style="flex:1; min-width:160px;">
+        <label for="tuning" style="margin-bottom:0.3rem;">Tuning <span style="font-weight:normal;color:#888;">(overrides Strings)</span></label>
+        <input type="text" id="tuning" placeholder="e.g. DADGBE, DAEAC#E" style="margin-bottom:0;" />
+      </div>
+    </div>
+
     <button id="btn" onclick="generate()">Generate</button>
     <span id="loading" style="display:none; margin-left:0.75rem;">Loading WASM…</span>
     <div id="error"></div>
@@ -120,6 +135,8 @@
       const vertical  = document.getElementById('vertical').checked;
       const show_ox   = document.getElementById('show_ox').checked;
       const show_notes = document.getElementById('show_notes').checked;
+      const strings   = parseInt(document.getElementById('strings').value) || 6;
+      const tuning    = document.getElementById('tuning').value.trim();
       const errEl     = document.getElementById('error');
       const outEl     = document.getElementById('output');
 
@@ -127,7 +144,7 @@
       if (!input) { outEl.innerHTML = ''; return; }
 
       try {
-        const svg = chord_to_svg(input, vertical, show_ox, 0, show_notes);
+        const svg = chord_to_svg(input, vertical, show_ox, 0, show_notes, strings, tuning);
         if (svg.startsWith('<!-- Error')) {
           errEl.textContent = svg.replace(/<!--\s*|\s*-->/g, '');
           outEl.innerHTML = '';
@@ -143,6 +160,12 @@
     // Generate on Enter key
     document.getElementById('input').addEventListener('keydown', e => {
       if (e.key === 'Enter') window.generate();
+    });
+
+    // Disable strings selector when tuning is specified
+    document.getElementById('tuning').addEventListener('input', () => {
+      document.getElementById('strings').disabled =
+        document.getElementById('tuning').value.trim() !== '';
     });
 
     load();


### PR DESCRIPTION
## Summary

- `chord_to_svg` WASM バインディングに `strings`（4/6/7弦）と `tuning`（例: `DADGBE`, `DAEAC#E`）パラメータを追加
- Web デモ UI に Strings セレクタと Tuning テキスト入力を追加
- チューニング入力時は Strings セレクタを自動無効化（CLI と同じ動作）
- カスタムチューニング時は `best_voicing_for_tuning()` を使用、標準6弦は従来通り CAGED 優先

## Test plan

- [ ] `C`（標準6弦）→ 従来通りの表示
- [ ] `Am7` + Strings=4 → ベース用ボイシング
- [ ] `A9` + Tuning=`DAEAC#E` → オープンAチューニング用ボイシング
- [ ] `320003` + Strings=6 → フレット文字列（変わらず動作）
- [ ] Tuning 入力中は Strings セレクタが無効化されること
- [ ] 無効なチューニング文字列（例: `XYZ`）→ エラー表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)